### PR TITLE
docker-compose: disable commands panel plugin by default

### DIFF
--- a/meta-enapter-core/recipes-enapter/enapter-initscripts/files/docker-compose.yml
+++ b/meta-enapter-core/recipes-enapter/enapter-initscripts/files/docker-compose.yml
@@ -16,6 +16,7 @@ version: "3"
 #    env_file: /user/etc/enapter/enapter-token.env
 #    environment:
 #      - 'ENAPTER_API_URL=http://10.88.0.1/api'
+#      - 'DISABLE_ENAPTER_COMMANDS_PANEL_PLUGIN=1'
 #    volumes:
 #      - /user/grafana-data:/var/lib/grafana
 #    image: enapter/grafana-plugins


### PR DESCRIPTION
This PR disables Grafana Enapter Commands Panel plugin by default as it does not work with the beta release of Enapter Platform 3.