### PR TITLE
docker-compose: a note about v3 support for commands plugin

### DIFF
--- a/meta-enapter-core/recipes-enapter/enapter-initscripts/files/docker-compose.yml
+++ b/meta-enapter-core/recipes-enapter/enapter-initscripts/files/docker-compose.yml
@@ -16,6 +16,7 @@ version: "3"
 #    env_file: /user/etc/enapter/enapter-token.env
 #    environment:
 #      - 'ENAPTER_API_URL=http://10.88.0.1/api'
+#      # NOTE: Making Commands Plugin support Platform V3 is on the way.
 #      - 'DISABLE_ENAPTER_COMMANDS_PANEL_PLUGIN=1'
 #    volumes:
 #      - /user/grafana-data:/var/lib/grafana


### PR DESCRIPTION
This PR adds a comment to the `docker-compose.yml` informing users about the ongoing efforts to support Platform V3 in Enapter Command Panel Grafana plugin.